### PR TITLE
Protocol Match Not Dependent On Containing an :

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,7 +1,7 @@
 module.exports = Plugin;
 
 function Plugin(db) {
-	if (db.driver.config.protocol != "mysql:") {
+	if (db.driver.config.protocol.match("mysql")) {
 		throw new Error("ORM MySQL FTS plugin does not support drivers other than MySQL");
 	}
 


### PR DESCRIPTION
This change enables users who config the orm through an object instead of an string to work with this plugin.

Now a config such as this will work

``` js
orm.connect({
    "protocol": "mysql",
    "host": "127.0.0.1",
    "database": "*********",
    "user": "*********",
    "password": "*********",
    "query": {
        "pool": true
    }
}, function (error, db) {
        .....
});
```
